### PR TITLE
Dockerize the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# ==================================
+# STAGE 1 - build a fat jar
+# ==================================
+FROM openjdk:11
+
+ENV SBT_VERSION 1.6.2
+
+RUN curl -L -o sbt-$SBT_VERSION.zip https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.zip
+RUN unzip sbt-$SBT_VERSION.zip -d ops
+
+WORKDIR /app
+
+# Copy all project libraries and build requirements
+COPY build.sbt /app/build.sbt
+COPY project/plugins.sbt /app/project/plugins.sbt
+COPY project/build.properties /app/project/build.properties
+
+# Copy the project
+COPY app /app/app
+COPY conf /app/conf
+COPY test /app/test
+COPY public /app/public
+
+# Generate a fat jar
+RUN /ops/sbt/bin/sbt package assembly
+
+# ==================================
+# STAGE 2 - build a slim jar
+# ==================================
+FROM openjdk:8-jre-alpine
+
+RUN mkdir -p /opt/scala-play-graphql
+WORKDIR /opt/scala-play-graphql
+COPY --from=0 /app/target/scala-2.13/scala-play-graphql-assembly-*.jar scala-play-graphql.jar
+CMD java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -jar scala-play-graphql.jar

--- a/README.md
+++ b/README.md
@@ -7,11 +7,22 @@ and [Sangria Playground](https://github.com/sangria-graphql/sangria-playground).
 
 ## Running locally
 
+### With sbt
+
 ```
 sbt clean compile run
 ```
 
 Hit the page at `locahost:9000`
+
+### With Docker
+
+Assuming you have Docker daemon running locally:
+```
+docker-compose build
+docker-compose up
+```
+Hit the page at `locahost:9000/health-check`
 
 ## Submitting a GraphQL request
 
@@ -51,7 +62,7 @@ Should return:
 			"image": {
 				"width": 500,
 				"height": 500,
-				"url": "//cdn.com/500/1.jpg"
+				"url": "//foo.bar/500/1.jpg"
 			}
 		},
 		"teams": [
@@ -67,11 +78,10 @@ Should return:
 ```
 
 ## TODOs
-- Dockerize the application
-- Use `docker-compose` to build and run app locally
 - Add DB with MySQL and store data there instead with migrations
 - Get POST with query parameter to work
 - Add e-2-e test
+- Github actions to run tests
 
 ## References
 - [sangria-graphql](https://sangria-graphql.github.io/getting-started/)

--- a/app/controllers/HealthController.scala
+++ b/app/controllers/HealthController.scala
@@ -1,0 +1,12 @@
+package controllers
+
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+
+import javax.inject._
+
+@Singleton
+class HealthController @Inject() (cc: ControllerComponents) extends AbstractController(cc) {
+
+  val healthCheck: Action[AnyContent] = Action(Ok("OK"))
+
+}

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -5,6 +5,12 @@ import play.api._
 import play.api.mvc._
 
 /**
+  * 2021-06-12 Issue when hitting routes pointing to this controller through Docker on Windows: Caused by:
+  * java.lang.UnsupportedClassVersionError: controllers/routes has been compiled by a more recent version of the Java
+  * Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
+  */
+
+/**
   * This controller creates an `Action` to handle HTTP requests to the application's home page.
   */
 @Singleton

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := """scala-play-graphql"""
 
-version := "1.0-SNAPSHOT"
+version := "1.0"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
@@ -22,8 +22,18 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-optics" % circeVersion
 )
 
-// Adds additional packages into Twirl
-//TwirlKeys.templateImports += "com.example.controllers._"
+javaOptions in Test += "-Dconfig.file=conf/application.test.conf"
 
-// Adds additional packages into conf/routes
-// play.sbt.routes.RoutesKeys.routesImport += "com.example.binders._"
+assembly / assemblyMergeStrategy := {
+  case PathList("module-info.class", _*)                                             => MergeStrategy.discard
+  case PathList("META-INF", _*)                                                      => MergeStrategy.discard
+  case referenceOverrides if referenceOverrides.contains("reference-overrides.conf") => MergeStrategy.concat
+  case a if a.contains("javax/activation")                                           => MergeStrategy.first
+  case o =>
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
+    oldStrategy(o)
+}
+
+// Skip scaladoc
+Compile / doc / sources := Nil
+Compile / packageDoc / publishArtifact := false

--- a/conf/application.test.conf
+++ b/conf/application.test.conf
@@ -1,4 +1,4 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
 play.http.secret.key="some-long-secret-should-be-encrypted-and-pulled-from-somewhere"
-play.http.secret.key=${HTTP_SECRET_KEY}
+# play.http.secret.key=${HTTP_SECRET_KEY}

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,9 @@
 # An example controller showing a sample home page
 GET     /                           controllers.HomeController.index()
 
+# Health check
+GET     /health-check               controllers.HealthController.healthCheck
+
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+
+  scala-play-graphql:
+    build: .
+    container_name: scala-play-graphql
+    ports:
+      - "9000:9000"
+    environment:
+      HTTP_SECRET_KEY: "some-long-secret-should-be-encrypted-and-pulled-from-somewhere"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.13.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")


### PR DESCRIPTION
Can now run the app locally with Docker

```
docker-compose build
docker-compose up
```

I kept running into this weird issue with the HomeController 
```
  java.lang.UnsupportedClassVersionError: controllers/routes has been compiled by a more recent version of the Java
  Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

The route `GET     /` works when running straight with `sbt run` but not with Docker on Windows.... Most likely a clash between java JRE/JDKs between my local environment and the images built for Docker containing this app.
