### PR TITLE
Log incoming requests to a DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ To get:
 ```
 
 ## TODOs
-- Log events to a DB
+- Authentication
 - Get POST with query parameter to work
 - Add e-2-e test
 

--- a/app/controllers/AppController.scala
+++ b/app/controllers/AppController.scala
@@ -13,17 +13,20 @@ import scala.concurrent.{ExecutionContext, Future}
 class AppController @Inject() (
     protected val service: Service,
     cc: ControllerComponents,
+    requestLoggingAction: RequestLoggingAction,
     implicit
     val ec: ExecutionContext
   ) extends AbstractController(cc) {
 
-  def teams: Action[JsValue] = Action.async(parse.json) { request =>
+  // Instead of calling "Action.async(parse.json)", we use our own action, which will log request metadata to a DB.
+  // This is useful for analysis purposes, but probably expensive with high traffic.
+  def teams: Action[JsValue] = requestLoggingAction.async(parse.json) { request =>
     dispatchQuery(service.teamService, request)
       .map(Ok(_))
       .recover(handleQueryExecutionError(_))
   }
 
-  def players: Action[JsValue] = Action.async(parse.json) { request =>
+  def players: Action[JsValue] = requestLoggingAction.async(parse.json) { request =>
     dispatchQuery(service.playerService, request)
       .map(Ok(_))
       .recover(handleQueryExecutionError(_))

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -5,12 +5,6 @@ import play.api._
 import play.api.mvc._
 
 /**
-  * 2021-06-12 Issue when hitting routes pointing to this controller through Docker on Windows: Caused by:
-  * java.lang.UnsupportedClassVersionError: controllers/routes has been compiled by a more recent version of the Java
-  * Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
-  */
-
-/**
   * This controller creates an `Action` to handle HTTP requests to the application's home page.
   */
 @Singleton

--- a/app/controllers/RequestLoggingAction.scala
+++ b/app/controllers/RequestLoggingAction.scala
@@ -1,0 +1,32 @@
+package controllers
+
+import com.google.inject.{Inject, Singleton}
+import models.RequestMetadata
+import play.api.mvc._
+import services.Service
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class LoggedRequest[A](request: Request[A])
+    extends WrappedRequest[A](request)
+
+// Logs request metadata to a DB.
+// This is useful for analysis purposes, but probably expensive with high traffic.
+@Singleton
+class RequestLoggingAction @Inject() (
+    val parser: BodyParsers.Default,
+    service: Service
+  )(implicit
+    val executionContext: ExecutionContext
+  ) extends ActionBuilder[LoggedRequest, AnyContent] {
+
+  // TODO: Clean up code!
+  override def invokeBlock[A](request: Request[A], block: LoggedRequest[A] => Future[Result]): Future[Result] = {
+    val requestMetadata = RequestMetadata.make(request)
+    for {
+      result <- block(new LoggedRequest(request))
+      _ = service.requestMetadataService.insert(requestMetadata)
+    } yield result
+
+  }
+}

--- a/app/dao/Database.scala
+++ b/app/dao/Database.scala
@@ -28,12 +28,21 @@ trait GenericSelectDbTrait {
 
 }
 
+trait GenericInsertDbTrait {
+  this: GenericAbstractDb =>
+
+  def insertRecord[A](sql: String, args: NamedParameter*)(implicit parser: RowParser[A]): Future[A] = Future(
+    db.withConnection(implicit conn => SQL(sql).on(args: _*).executeInsert(parser.single))
+  )(dbEC)
+}
+
 // ====================================================================================
 // Database - Implementation
 // ====================================================================================
 class PostgresDB @Inject() (db: Database, dbEC: DefaultDbExecutionContext)
     extends GenericAbstractDb(db, dbEC)
        with GenericSelectDbTrait
+       with GenericInsertDbTrait
 
 object QueryUtils {
   def makeSingleWhereClause(singleClause: String) = s"where $singleClause"

--- a/app/dao/RequestMetadataDao.scala
+++ b/app/dao/RequestMetadataDao.scala
@@ -1,0 +1,51 @@
+package dao
+
+import anorm.RowParser
+import anorm.SqlParser._
+import models.RequestMetadata
+import play.api.Logger
+
+import java.util.UUID
+import scala.concurrent.Future
+
+trait RequestMetadataDao {
+  def insert(requestMeta: RequestMetadata): Future[UUID]
+}
+
+class RequestMetadataDaoImpl(debugMode: Boolean)(implicit db: PostgresDB) extends DimensionDao with RequestMetadataDao {
+
+  implicit private val logger: Logger = Logger(this.getClass)
+
+  private val pkParser: RowParser[UUID] = get[UUID](1)
+  private val genIdFunction = "uuid_generate_v4()"
+  private val Cols: String = List("id, datetime", "uri", "body").mkString(",")
+
+  override val TableName: String = "request_metadata"
+  override val SELECT_RECORDS: String =
+    s""" SELECT
+       | id::varchar, $Cols
+       | FROM $TableName $SELECT_ALIAS
+       |""".stripMargin
+
+  val INSERT_RECORD: String =
+    s""" INSERT INTO $TableName ($Cols)
+       | VALUES ($genIdFunction, {datetime}, {uri}, {body})
+       | RETURNING id
+       |""".stripMargin
+
+  override def insert(requestMeta: RequestMetadata): Future[UUID] = {
+
+    if (debugMode) {
+      logger.info(
+        s"Logging request [time= ${requestMeta.datetime}] [uri= ${requestMeta.uri}] [body= ${requestMeta.body}...]"
+      )
+    }
+
+    db.insertRecord(
+      INSERT_RECORD,
+      Symbol("datetime") -> requestMeta.datetime,
+      Symbol("uri") -> requestMeta.uri,
+      Symbol("body") -> requestMeta.body
+    )(pkParser)
+  }
+}

--- a/app/models/RequestMetadata.scala
+++ b/app/models/RequestMetadata.scala
@@ -1,0 +1,21 @@
+package models
+
+import play.api.mvc.Request
+
+import java.time.LocalDateTime
+
+case class RequestMetadata(
+    datetime: LocalDateTime,
+    uri: String,
+    body: String
+  )
+
+object RequestMetadata {
+  private val RequestBodySizeToLog: Int = 30
+  def make[A](request: Request[A]): RequestMetadata =
+    RequestMetadata(
+      datetime = LocalDateTime.now(),
+      uri = request.uri,
+      body = request.body.toString.take(RequestBodySizeToLog)
+    )
+}

--- a/app/services/RequestMetadataService.scala
+++ b/app/services/RequestMetadataService.scala
@@ -1,0 +1,16 @@
+package services
+
+import dao.RequestMetadataDao
+import models.RequestMetadata
+
+import java.util.UUID
+import scala.concurrent.Future
+
+trait RequestMetadataService {
+  def insert(requestMeta: RequestMetadata): Future[UUID]
+}
+
+class RequestMetadataServiceImpl(dao: RequestMetadataDao) extends RequestMetadataService {
+  override def insert(requestMeta: RequestMetadata): Future[UUID] =
+    dao.insert(requestMeta)
+}

--- a/app/services/Service.scala
+++ b/app/services/Service.scala
@@ -1,6 +1,6 @@
 package services
 
-import dao.{PlayerDaoImpl, PlayerRepo, PostgresDB, GraphQlRepo, TeamDaoImpl, TeamRepo}
+import dao.{GraphQlRepo, PlayerDaoImpl, PlayerRepo, PostgresDB, RequestMetadataDaoImpl, TeamDaoImpl, TeamRepo}
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
@@ -12,6 +12,9 @@ class Service @Inject() (
     graphQlDb: PostgresDB,
     ec: ExecutionContext
   ) {
+
+  private val requestMetadataDao = new RequestMetadataDaoImpl(debugMode = true)
+  val requestMetadataService = new RequestMetadataServiceImpl(requestMetadataDao)
 
   implicit val teamDaoImpl: TeamDaoImpl = new TeamDaoImpl()
   implicit val playerDaoImpl: PlayerDaoImpl = new PlayerDaoImpl()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,6 +4,7 @@ play.http.secret.key="some-long-secret-should-be-encrypted-and-pulled-from-somew
 # play.http.secret.key=${HTTP_SECRET_KEY}
 
 play.filters.disabled+=play.filters.hosts.AllowedHostsFilter
+play.filters.disabled+=play.filters.csrf.CSRFFilter
 
 # DB Connections
 db.default.driver="org.postgresql.Driver"

--- a/conf/evolutions/default/3.sql
+++ b/conf/evolutions/default/3.sql
@@ -1,0 +1,12 @@
+-- !Ups
+
+create table request_metadata(
+    id          uuid not null constraint pk_request_metadata primary key,
+    datetime    timestamp default null,
+    uri         varchar default null,
+    body        varchar default null
+);
+
+-- !Downs
+
+DROP TABLE request_metadata;

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -39,4 +39,9 @@
     <appender-ref ref="ASYNCSTDOUT" />
   </root>
 
+  <!--  Enable INFO logging to the console-->
+  <root level="INFO">
+    <appender-ref ref="ASYNCSTDOUT"/>
+  </root>
+
 </configuration>

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -6,11 +6,10 @@ import play.api.test._
 import play.api.test.Helpers._
 
 /**
- * Add your spec here.
- * You can mock out a whole application including requests, plugins etc.
- *
- * For more information, see https://www.playframework.com/documentation/latest/ScalaTestingWithScalaTest
- */
+  * Add your spec here. You can mock out a whole application including requests, plugins etc.
+  *
+  * For more information, see https://www.playframework.com/documentation/latest/ScalaTestingWithScalaTest
+  */
 class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting {
 
   "HomeController GET" should {
@@ -21,7 +20,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include("Welcome to Play")
     }
 
     "render the index page from the application" in {
@@ -30,7 +29,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include("Welcome to Play")
     }
 
     "render the index page from the router" in {
@@ -39,7 +38,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include("Welcome to Play")
     }
   }
 }


### PR DESCRIPTION
`RequestLoggingAction` was added to wrap a request and automatically log information to a DB before we serve the request.
Evolutions were updated to create a new table `request_metadata` where we will store such data.
Body of a request might be large so for this example we just store the first `30`  chars.

```
2022-07-07 16:52:22 INFO  dao.RequestMetadataDaoImpl  Logging request [time= 2022-07-07T16:52:21.646] [uri= /player] [body= {"query":"\n    query Introspe...]
2022-07-07 16:52:25 INFO  dao.RequestMetadataDaoImpl  Logging request [time= 2022-07-07T16:52:25.314] [uri= /team] [body= {"query":"\n    query Introspe...]
2022-07-07 16:52:26 INFO  dao.RequestMetadataDaoImpl  Logging request [time= 2022-07-07T16:52:26.029] [uri= /team] [body= {"query":"query MyTeam {\n\tte...]
2022-07-07 16:52:27 INFO  dao.RequestMetadataDaoImpl  Logging request [time= 2022-07-07T16:52:27.193] [uri= /player] [body= {"query":"\n    query Introspe...]
2022-07-07 16:52:27 INFO  dao.RequestMetadataDaoImpl  Logging request [time= 2022-07-07T16:52:27.892] [uri= /player] [body= {"query":"query MyPlayer {\n\t...]
```

When querying a local db:
![image](https://user-images.githubusercontent.com/2423200/177870211-4238aa9a-9ae1-4f80-a884-490040055fdd.png)

